### PR TITLE
Adds usage information to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,11 @@ node v8.0.0 added support for a built-in `util.promisify`: https://github.com/no
 
 This package provides the built-in `util.promisify` in node v8.0.0 and later, and a replacement in other environments.
 
+## Usage
+
+```js
+const promisify = require('util.promisify')
+// Use `promisify` just like the built-in
+```
+
 Note: this package requires a native ES5 environment, and for `Promise` to be globally available. It will throw upon requiring it if these are not present.


### PR DESCRIPTION
Adds usage information to the README.  Having this information in the README saves users from wondering how to access the polyfill.