### PR TITLE
Add TypeScript types definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,34 @@
+// Type definitions for util.promisify 1.0.0
+// Project: https://github.com/ljharb/util.promisify
+
+/*~ Note that ES6 modules cannot directly export callable functions.
+ *~ This file should be imported using the CommonJS-style:
+ *~   import x = require('util.promisify');
+ *~
+ *~ Refer to the documentation to understand common
+ *~ workarounds for this limitation of ES6 modules.
+ */
+export = promifify;
+
+declare function promifify(f: Function): Function
+
+declare namespace promifify {
+    interface implementation {
+        (fn: Function): Function;
+        custom: symbol
+        customPromisifyArgs: symbol | undefined
+    }
+
+    export const custom: symbol
+	export const customPromisifyArgs: symbol
+	export function getPolyfill(): Function
+    export const implementation: implementation
+	export function shim(): implementation
+}
+
+declare module "util" {
+    export var promisify: {
+        (fn: Function): Function;
+        custom: symbol
+    }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "1.0.0",
 	"description": "Polyfill/shim for util.promisify in node versions < v8",
 	"main": "index.js",
+	"types": "index.d.ts",
 	"dependencies": {
 		"define-properties": "^1.1.2",
 		"has-symbols": "^1.0.0",


### PR DESCRIPTION
This enables better automatic completion information as well as allow TypeScript users to have type checking and the ability to use this library in strict mode (default on new projects).