### PR TITLE
src: Remove ES5/6 shim dependencies

### DIFF
--- a/implementation.js
+++ b/implementation.js
@@ -9,7 +9,7 @@ if (!isES5) {
 	throw new TypeError('util.promisify requires a true ES5 environment');
 }
 
-var getOwnPropertyDescriptors = require('object.getownpropertydescriptors');
+var getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 
 if (typeof Promise !== 'function') {
 	throw new TypeError('`Promise` must be globally available for util.promisify to work.');
@@ -19,10 +19,20 @@ var slice = Function.call.bind(Array.prototype.slice);
 var concat = Function.call.bind(Array.prototype.concat);
 var forEach = Function.call.bind(Array.prototype.forEach);
 
-var hasSymbols = require('has-symbols')();
+var hasSymbols = typeof global.Symbol !== 'function';
 
 var kCustomPromisifiedSymbol = hasSymbols ? Symbol('util.promisify.custom') : null;
 var kCustomPromisifyArgsSymbol = hasSymbols ? Symbol('customPromisifyArgs') : null;
+
+var getOwnPropertyDescriptors = function _getOwnPropertyDescriptors(obj) {
+	var out = {};
+	var keys = Object.keys(obj);
+
+	for (var index = 0; index < keys.length; index++) {
+		out[keys[index]] = getOwnPropertyDescriptor(obj, keys[index]);
+	}
+	return out;
+};
 
 module.exports = function promisify(orig) {
 	if (typeof orig !== 'function') {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var define = require('define-properties');
+var define = Object.defineProperties;
 var util = require('util');
 
 var implementation = require('./implementation');
@@ -8,17 +8,26 @@ var getPolyfill = require('./polyfill');
 var polyfill = getPolyfill();
 var shim = require('./shim');
 
+var makeDescriptor = function _makeDescriptor(value) {
+	return {
+		configurable: true,
+		enumerable: false,
+		value: value,
+		writable: true
+	};
+};
+
 /* eslint-disable no-unused-vars */
 var boundPromisify = function promisify(orig) {
 /* eslint-enable no-unused-vars */
 	return polyfill.apply(util, arguments);
 };
 define(boundPromisify, {
-	custom: polyfill.custom,
-	customPromisifyArgs: polyfill.customPromisifyArgs,
-	getPolyfill: getPolyfill,
-	implementation: implementation,
-	shim: shim
+	custom: makeDescriptor(polyfill.custom),
+	customPromisifyArgs: makeDescriptor(polyfill.customPromisifyArgs),
+	getPolyfill: makeDescriptor(getPolyfill),
+	implementation: makeDescriptor(implementation),
+	shim: makeDescriptor(shim)
 });
 
 module.exports = boundPromisify;

--- a/package.json
+++ b/package.json
@@ -3,11 +3,7 @@
 	"version": "1.0.0",
 	"description": "Polyfill/shim for util.promisify in node versions < v8",
 	"main": "index.js",
-	"dependencies": {
-		"define-properties": "^1.1.3",
-		"has-symbols": "^1.0.1",
-		"object.getownpropertydescriptors": "^2.0.3"
-	},
+	"dependencies": {},
 	"devDependencies": {
 		"@es-shims/api": "^2.1.2",
 		"@ljharb/eslint-config": "^15.0.2",


### PR DESCRIPTION
This project is a pretty lightweight module and can be implemented
as a zero dependency library.

The actual implementation is basically 20 lines itself.

Since this module already depends on ES5 & global.Promise I
inlined the other 3 dependencies it has (all pretty trivial).

This makes this module zero dependency which makes it really
lightweight!

The motiviation for this is to simplify `aws-sdk` ;

Currently for aws-sdk; 50% of the transitive dependencies are
the dependencies of `util.promisify` itself ( 24 ). This is
quite a lot of weight.

Fixes https://github.com/ljharb/util.promisify/issues/14