### PR TITLE
[New] use a global symbol for `util.promisify.custom`

### DIFF
--- a/implementation.js
+++ b/implementation.js
@@ -24,7 +24,8 @@ var $forEach = callBound('Array.prototype.forEach');
 
 var hasSymbols = require('has-symbols')();
 
-var kCustomPromisifiedSymbol = hasSymbols ? Symbol('util.promisify.custom') : null;
+// eslint-disable-next-line no-restricted-properties
+var kCustomPromisifiedSymbol = hasSymbols ? Symbol['for']('nodejs.util.promisify.custom') : null;
 var kCustomPromisifyArgsSymbol = hasSymbols ? Symbol('customPromisifyArgs') : null;
 
 module.exports = function promisify(orig) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
 		"call-bind": "^1.0.0",
 		"define-properties": "^1.1.3",
 		"for-each": "^0.3.3",
-		"has-symbols": "^1.0.1",
 		"object.getownpropertydescriptors": "^2.1.0"
 	},
 	"devDependencies": {
@@ -16,6 +15,7 @@
 		"aud": "^1.1.3",
 		"auto-changelog": "^2.2.1",
 		"eslint": "^7.17.0",
+		"has-symbols": "^1.0.1",
 		"nyc": "^10.3.2",
 		"safe-publish-latest": "^1.1.4",
 		"tape": "^5.1.1"

--- a/polyfill.js
+++ b/polyfill.js
@@ -4,7 +4,7 @@ var util = require('util');
 var implementation = require('./implementation');
 
 module.exports = function getPolyfill() {
-	if (typeof util.promisify === 'function') {
+	if (typeof util.promisify === 'function' && util.promisify.custom === implementation.custom) {
 		return util.promisify;
 	}
 	return implementation;

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var hasSymbols = require('has-symbols')();
+
 module.exports = function runTests(promisify, t) {
 	t.equal(typeof promisify, 'function', 'promisify is a function');
 
@@ -40,5 +42,13 @@ module.exports = function runTests(promisify, t) {
 		return p.then(null, function (args) {
 			st.deepEqual(args, [1, 2, 3], 'rejection: arguments are preserved');
 		});
+	});
+
+	t.test('custom symbol', { skip: !hasSymbols }, function (st) {
+		st.equal(Symbol.keyFor(promisify.custom), 'nodejs.util.promisify.custom', 'is a global symbol with the right key');
+		// eslint-disable-next-line no-restricted-properties
+		st.equal(Symbol['for']('nodejs.util.promisify.custom'), promisify.custom, 'is the global symbol');
+
+		st.end();
 	});
 };


### PR DESCRIPTION
Define `util.promisify.custom` as:
```js
Symbol.for("nodejs.util.inspect.custom")
```

rather than as:
```js
Symbol("util.inspect.custom")
```

This allows custom `promisify` wrappers to easily/safely be defined in non‑Node.js environments and for non‑Node `promisify` implementations to be interoperable.

## See also:

- https://github.com/nodejs/node/issues/31647
- https://github.com/nodejs/node/pull/31672