### PR TITLE
fix: add missing dependency has-symbols

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"call-bind": "^1.0.0",
 		"define-properties": "^1.1.3",
 		"for-each": "^0.3.3",
+		"has-symbols": "^1.0.1",
 		"object.getownpropertydescriptors": "^2.1.1"
 	},
 	"devDependencies": {
@@ -15,7 +16,6 @@
 		"aud": "^1.1.3",
 		"auto-changelog": "^2.2.1",
 		"eslint": "^7.17.0",
-		"has-symbols": "^1.0.1",
 		"nyc": "^10.3.2",
 		"safe-publish-latest": "^1.1.4",
 		"tape": "^5.1.1"


### PR DESCRIPTION
**What's the problem this PR addresses?**

`util.promisify` is using `has-symbols` without declaring it as a dependency which makes it rely on something else in the dependency tree to declare it and hoisting to be gracious enough to place it in an accesible location neither of which is guaranteed. It was moved from `dependencies` to `devDependencies` in https://github.com/ljharb/util.promisify/commit/8f8631b04c3f2cf1bd082837c8d73431e356eb2f

Noticed by the Yarn PnP test in https://github.com/preactjs/preact-cli/pull/1418

**How did you fix it?**

Moved it back